### PR TITLE
Changed field view format for image to use large size instead of source

### DIFF
--- a/plugins/bean/StanfordToggleBlock.php
+++ b/plugins/bean/StanfordToggleBlock.php
@@ -96,7 +96,7 @@ class StanfordToggleBlock extends BeanDefault {
       $right[$fc->item_id]["#suffix"] = "</div>";
 
       // Image.
-      $right[$fc->item_id]['image'] = field_view_field('field_collection_item', $fc, 'field_s_toggle_image', array("label" => "hidden"));
+      $right[$fc->item_id]['image'] = field_view_field('field_collection_item', $fc, 'field_s_toggle_image', array("label" => "hidden", 'settings' => array('image_style' => 'large')));
       $right[$fc->item_id]['image']["#prefix"] = "<div class=\"toggle-block-image\">";
       $right[$fc->item_id]['image']["#suffix"] = "</div>";
       $right[$fc->item_id]['image']["#weight"] = 0;

--- a/plugins/bean/StanfordToggleBlock.php
+++ b/plugins/bean/StanfordToggleBlock.php
@@ -96,7 +96,8 @@ class StanfordToggleBlock extends BeanDefault {
       $right[$fc->item_id]["#suffix"] = "</div>";
 
       // Image.
-      $right[$fc->item_id]['image'] = field_view_field('field_collection_item', $fc, 'field_s_toggle_image', array("label" => "hidden", 'settings' => array('image_style' => 'large')));
+      $info = field_info_instance('field_collection_item', 'field_s_toggle_image', 'field_s_toggle_tab');
+      $right[$fc->item_id]['image'] = field_view_field('field_collection_item', $fc, 'field_s_toggle_image', array("label" => "hidden", 'settings' => $info['display']['default']['settings']));
       $right[$fc->item_id]['image']["#prefix"] = "<div class=\"toggle-block-image\">";
       $right[$fc->item_id]['image']["#suffix"] = "</div>";
       $right[$fc->item_id]['image']["#weight"] = 0;

--- a/stanford_toggle_block.features.field_instance.inc
+++ b/stanford_toggle_block.features.field_instance.inc
@@ -253,7 +253,7 @@ function stanford_toggle_block_field_default_field_instances() {
         'module' => 'image',
         'settings' => array(
           'image_link' => '',
-          'image_style' => 'large-scaled',
+          'image_style' => 'page-width',
         ),
         'type' => 'image',
         'weight' => 0,

--- a/stanford_toggle_block.info
+++ b/stanford_toggle_block.info
@@ -11,6 +11,7 @@ dependencies[] = field_group
 dependencies[] = image
 dependencies[] = link
 dependencies[] = text
+dependencies[] = stanford_image_styles
 features[bean_type][] = stanford_toggle_block
 features[ctools][] = bean_admin_ui:bean:5
 features[ctools][] = field_group:field_group:1


### PR DESCRIPTION
So we don't get 7.5mb images on pages.
